### PR TITLE
[5 pontos] Integrar Prometheus e Grafana para monitoramento

### DIFF
--- a/CidadeIntegra/CidadeIntegra.API/CidadeIntegra.API.csproj
+++ b/CidadeIntegra/CidadeIntegra.API/CidadeIntegra.API.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <PackageReference Include="DotNetEnv" Version="3.1.1" />
     <PackageReference Include="Google.Cloud.Firestore" Version="3.12.0" />
+    <PackageReference Include="prometheus-net.AspNetCore" Version="8.2.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
   </ItemGroup>
 

--- a/CidadeIntegra/CidadeIntegra.API/Program.cs
+++ b/CidadeIntegra/CidadeIntegra.API/Program.cs
@@ -4,6 +4,7 @@ using CidadeIntegra.Infra.IoC;
 using DotNetEnv;
 using Google.Cloud.Firestore;
 using Microsoft.OpenApi.Models;
+using Prometheus;
 
 namespace CidadeIntegra.API
 {
@@ -113,10 +114,19 @@ namespace CidadeIntegra.API
             builder.Services.AddInfrastructureAPI(builder.Configuration);
             #endregion
 
+            #region Configuração Prometheus
+            builder.Services.AddHealthChecks();
+            #endregion
+
             builder.Services.AddControllers();
-            // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
-            builder.Services.AddEndpointsApiExplorer();
             builder.Services.AddSwaggerGen();
+
+            #region Escutar interfaces na porta 80
+            builder.WebHost.ConfigureKestrel(options =>
+            {
+                options.ListenAnyIP(80); // escuta em todas as interfaces na porta 80
+            });
+            #endregion
 
             var app = builder.Build();
 
@@ -137,11 +147,19 @@ namespace CidadeIntegra.API
             app.UseMiddleware<ExceptionHandlingMiddleware>();
             #endregion
 
-            app.UseHttpsRedirection();
-
             app.UseAuthorization();
 
+            #region Métricas - Prometheus
+            app.UseMetricServer();
+            app.UseHttpMetrics();
+            app.MapMetrics();
+            #endregion
+
             app.MapControllers();
+
+            #region healthcheck
+            app.MapHealthChecks("/health");
+            #endregion
 
             app.Run();
         }

--- a/CidadeIntegra/docker-compose.yml
+++ b/CidadeIntegra/docker-compose.yml
@@ -31,6 +31,27 @@ services:
     networks:
       - cidadeintegra-network
 
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: prometheus
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+    ports:
+      - "9090:9090"
+    networks:
+      - cidadeintegra-network
+
+  grafana:
+    image: grafana/grafana:latest
+    container_name: grafana
+    environment:
+      - GF_SECURITY_ADMIN_USER=admin
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+    ports:
+      - "3000:3000"
+    networks:
+      - cidadeintegra-network
+
 volumes:
   sql_data:
 

--- a/CidadeIntegra/prometheus.yml
+++ b/CidadeIntegra/prometheus.yml
@@ -1,0 +1,8 @@
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: 'cidadeintegra-api'
+    metrics_path: '/metrics'
+    static_configs:
+      - targets: ['cidadeintegra-api:80']  # Nome do serviço no Docker Compose + porta do app


### PR DESCRIPTION
### [5 pontos] Integrar Prometheus e Grafana para monitoramento

#### Descrição

Configurar monitoramento da API com métricas expostas via Prometheus e visualização no Grafana.

#### Objetivo

-   Adicionar endpoint `/metrics` com `prometheus-net`.    
-   Criar `docker-compose` com serviços de Prometheus e Grafana.    
-   Configurar dashboards para requisições e tempo de resposta da API.

#### Pontuação: 5 pontos

#### Branch: `observability/prometheus-grafana`