### PR TITLE
[5 pontos] Adicionar Docker e Docker Compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -402,3 +402,4 @@ FodyWeavers.xsd
 # JetBrains Rider
 *.sln.iml
 /CidadeIntegra/CidadeIntegra.API/firebase-key.json
+CidadeIntegra/migration.sql

--- a/.gitignore
+++ b/.gitignore
@@ -401,3 +401,4 @@ FodyWeavers.xsd
 
 # JetBrains Rider
 *.sln.iml
+/CidadeIntegra/CidadeIntegra.API/firebase-key.json

--- a/CidadeIntegra/CidadeIntegra.API/CidadeIntegra.API.csproj
+++ b/CidadeIntegra/CidadeIntegra.API/CidadeIntegra.API.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="DotNetEnv" Version="3.1.1" />
+    <PackageReference Include="Google.Cloud.Firestore" Version="3.12.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
   </ItemGroup>
 

--- a/CidadeIntegra/CidadeIntegra.API/CidadeIntegra.API.csproj
+++ b/CidadeIntegra/CidadeIntegra.API/CidadeIntegra.API.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <PackageReference Include="DotNetEnv" Version="3.1.1" />
     <PackageReference Include="Google.Cloud.Firestore" Version="3.12.0" />
+    <PackageReference Include="prometheus-net.AspNetCore" Version="8.2.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
   </ItemGroup>
 

--- a/CidadeIntegra/CidadeIntegra.API/Program.cs
+++ b/CidadeIntegra/CidadeIntegra.API/Program.cs
@@ -4,6 +4,7 @@ using CidadeIntegra.Infra.IoC;
 using DotNetEnv;
 using Google.Cloud.Firestore;
 using Microsoft.OpenApi.Models;
+using Prometheus;
 
 namespace CidadeIntegra.API
 {
@@ -113,10 +114,19 @@ namespace CidadeIntegra.API
             builder.Services.AddInfrastructureAPI(builder.Configuration);
             #endregion
 
+            #region Configuração Prometheus
+            builder.Services.AddHealthChecks();
+            #endregion
+
             builder.Services.AddControllers();
-            // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
-            builder.Services.AddEndpointsApiExplorer();
             builder.Services.AddSwaggerGen();
+
+            #region Escutar interfaces na porta 80
+            builder.WebHost.ConfigureKestrel(options =>
+            {
+                options.ListenAnyIP(80); // escuta em todas as interfaces na porta 80
+            });
+            #endregion
 
             var app = builder.Build();
 
@@ -137,11 +147,19 @@ namespace CidadeIntegra.API
             app.UseMiddleware<ExceptionHandlingMiddleware>();
             #endregion
 
-            app.UseHttpsRedirection();
-
             app.UseAuthorization();
 
+            #region Métricas - Prometheus
+            app.UseMetricServer();
+            app.UseHttpMetrics();
+            app.MapMetrics();
+            #endregion
+
             app.MapControllers();
+
+            #region healthcheck
+            app.MapHealthChecks("/health");
+            #endregion
 
             app.Run();
         }

--- a/CidadeIntegra/CidadeIntegra.API/Program.cs
+++ b/CidadeIntegra/CidadeIntegra.API/Program.cs
@@ -13,44 +13,65 @@ namespace CidadeIntegra.API
         {
             var builder = WebApplication.CreateBuilder(args);
 
-            #region Configurações Firebase
-            // Configurações do Firebase (appsettings.json)
-            var projectId = builder.Configuration["Firebase:ProjectId"];
-            var serviceAccountPath = builder.Configuration["Firebase:ServiceAccountPath"];
+            #region Configuraï¿½ï¿½o Variï¿½veis de Ambiente
+            builder.Configuration.AddEnvironmentVariables();
+            Env.Load();
 
-            // Inicializa conexão com Firestore
-            FirestoreDb firestore = FirebaseInitializer.InitializeFirestore(projectId, serviceAccountPath);
+#if DEBUG
+            var testKey = Environment.GetEnvironmentVariable("MIGRATION_API_KEY");
+            if (string.IsNullOrEmpty(testKey))
+                Console.ForegroundColor = ConsoleColor.Red;
+            else
+                Console.ForegroundColor = ConsoleColor.Green;
 
-            // Injeta Firestore no container de dependência
-            builder.Services.AddSingleton(firestore);
+            Console.WriteLine($"MIGRATION_API_KEY: {(string.IsNullOrEmpty(testKey) ? "nï¿½o encontrada" : "carregada com sucesso")}");
+            Console.ResetColor();
+#endif
+
             #endregion
 
-            #region Configurações Swagger
-            // configura o Swagger para documentação e testes da API
+            #region ConfiguraÃ§Ãµes Firebase
+
+            var projectId = builder.Configuration["Firebase:ProjectId"];
+
+            // caminho dinÃ¢mico que funciona no Docker e Windows
+            var serviceAccountPath = Path.Combine(AppContext.BaseDirectory, "firebase-key.json");
+
+            Environment.SetEnvironmentVariable("GOOGLE_APPLICATION_CREDENTIALS", serviceAccountPath);
+            
+
+            FirestoreDb firestore = FirebaseInitializer.InitializeFirestore(projectId, serviceAccountPath);
+
+            builder.Services.AddSingleton(firestore);
+
+            #endregion
+
+            #region Configuraï¿½ï¿½es Swagger
+            // configura o Swagger para documentaï¿½ï¿½o e testes da API
             builder.Services.AddEndpointsApiExplorer();
 
             builder.Services.AddSwaggerGen(c =>
             {
-                // define informações básicas da API
+                // define informaï¿½ï¿½es bï¿½sicas da API
                 c.SwaggerDoc("v1", new OpenApiInfo
                 {
                     Title = "Cidade Integra API",
                     Version = "v1",
-                    Description = "API para migração de dados do Firestore para SQL Server"
+                    Description = "API para migraï¿½ï¿½o de dados do Firestore para SQL Server"
                 });
 
-                // adiciona suporte a autenticação via API Key
+                // adiciona suporte a autenticaï¿½ï¿½o via API Key
                 c.AddSecurityDefinition("ApiKey", new OpenApiSecurityScheme
                 {
-                    Description = "Chave de autenticação necessária para acessar endpoints protegidos.\n" +
+                    Description = "Chave de autenticaï¿½ï¿½o necessï¿½ria para acessar endpoints protegidos.\n" +
                                   "Insira no header: 'x-api-key'.",
                     Name = "x-api-key",              // nome do header
                     In = ParameterLocation.Header,    // local de envio do header
-                    Type = SecuritySchemeType.ApiKey, // tipo de autenticação
+                    Type = SecuritySchemeType.ApiKey, // tipo de autenticaï¿½ï¿½o
                     Scheme = "ApiKeyScheme"
                 });
 
-                // aplica a exigência da API key globalmente em todos os endpoints
+                // aplica a exigï¿½ncia da API key globalmente em todos os endpoints
                 c.AddSecurityRequirement(new OpenApiSecurityRequirement
                 {
                     {
@@ -68,7 +89,7 @@ namespace CidadeIntegra.API
             });
             #endregion
 
-            #region Configuração CORS
+            #region Configuraï¿½ï¿½o CORS
             builder.Services.AddCors(options =>
             {
                 options.AddPolicy("OpenCors", policy =>
@@ -80,31 +101,14 @@ namespace CidadeIntegra.API
             });
             #endregion
 
-            #region Configuração Logging Global
-            builder.Logging.ClearProviders(); // Remove qualquer configuração padrão de log
+            #region Configuraï¿½ï¿½o Logging Global
+            builder.Logging.ClearProviders(); // Remove qualquer configuraï¿½ï¿½o padrï¿½o de log
             builder.Logging.AddConsole(); // Envia todos os logs para o console
             builder.Logging.AddDebug(); // Envia logs para o Visual Studio Debug Output
-            builder.Logging.SetMinimumLevel(LogLevel.Information); // Define o nível mínimo de log a ser registrado
+            builder.Logging.SetMinimumLevel(LogLevel.Information); // Define o nï¿½vel mï¿½nimo de log a ser registrado
             #endregion
 
-            #region Configuração Variáveis de Ambiente
-            builder.Configuration.AddEnvironmentVariables();
-            Env.Load();
-
-            #if DEBUG
-                var testKey = Environment.GetEnvironmentVariable("MIGRATION_API_KEY");
-                if (string.IsNullOrEmpty(testKey))
-                    Console.ForegroundColor = ConsoleColor.Red;
-                else
-                    Console.ForegroundColor = ConsoleColor.Green;
-
-                Console.WriteLine($"MIGRATION_API_KEY: {(string.IsNullOrEmpty(testKey) ? "não encontrada" : "carregada com sucesso")}");
-                Console.ResetColor();
-            #endif
-
-            #endregion
-
-            #region Configuração IoC
+            #region Configuraï¿½ï¿½o IoC
             // Add services to the container.
             builder.Services.AddInfrastructureAPI(builder.Configuration);
             #endregion
@@ -116,20 +120,20 @@ namespace CidadeIntegra.API
 
             var app = builder.Build();
 
-            #region Configuração Pipeline Swagger
-            // Configuração do pipeline de requisição
+            #region Configuraï¿½ï¿½o Pipeline Swagger
+            // Configuraï¿½ï¿½o do pipeline de requisiï¿½ï¿½o
             if (app.Environment.IsDevelopment())
             {
                 app.UseSwagger();
                 app.UseSwaggerUI(c =>
                 {
-                    // Título e endpoint da documentação
+                    // Tï¿½tulo e endpoint da documentaï¿½ï¿½o
                     c.SwaggerEndpoint("/swagger/v1/swagger.json", "Cidade Integra API v1");
                 });
             }
             #endregion
 
-            #region Configuração Middleware
+            #region Configuraï¿½ï¿½o Middleware
             app.UseMiddleware<ExceptionHandlingMiddleware>();
             #endregion
 

--- a/CidadeIntegra/CidadeIntegra.API/appsettings.json
+++ b/CidadeIntegra/CidadeIntegra.API/appsettings.json
@@ -6,11 +6,10 @@
     }
   },
   "ConnectionStrings": {
-    "DefaultConnection": "Data Source=BIB-D12\\SQLEXPRESS;Initial Catalog=db_teste;Integrated Security=True"
+    "DefaultConnection": "Data Source=sqlserver;Initial Catalog=db_cidade_integra;Persist Security Info=True;User ID=sa;Password=UndY|n3vc^56;Trust Server Certificate=True"
   },
   "AllowedHosts": "*",
   "Firebase": {
-    "ProjectId": "cidadeintegra",
-    "ServiceAccountPath": "C:\\Users\\2971392411001\\Downloads\\firebase-key.json"
+    "ProjectId": "cidadeintegra"
   }
 }

--- a/CidadeIntegra/CidadeIntegra.Application/Services/MigrationService.cs
+++ b/CidadeIntegra/CidadeIntegra.Application/Services/MigrationService.cs
@@ -32,7 +32,7 @@ namespace CidadeIntegra.Application.Services
             _logger = logger;
 
             var projectId = configuration["Firebase:ProjectId"];
-            var credentialsPath = configuration["Firebase:ServiceAccountPath"];
+            var credentialsPath = Path.Combine(AppContext.BaseDirectory, "firebase-key.json");
             Environment.SetEnvironmentVariable("GOOGLE_APPLICATION_CREDENTIALS", credentialsPath);
 
             _firestore = FirestoreDb.Create(projectId);

--- a/CidadeIntegra/CidadeIntegra.Infra.Data/Firebase/FirebaseInitializer.cs
+++ b/CidadeIntegra/CidadeIntegra.Infra.Data/Firebase/FirebaseInitializer.cs
@@ -8,22 +8,31 @@ namespace CidadeIntegra.Infra.Data.Firebase
     {
         public static FirestoreDb InitializeFirestore(string projectId, string serviceAccountPath)
         {
-            using var stream = new FileStream(serviceAccountPath, FileMode.Open, FileAccess.Read);
-            var credential = GoogleCredential.FromStream(stream);
-
-            FirebaseApp.Create(new AppOptions
+            try
             {
-                Credential = credential,
-                ProjectId = projectId
-            });
+                using var stream = new FileStream(serviceAccountPath, FileMode.Open, FileAccess.Read);
+                var credential = GoogleCredential.FromStream(stream);
 
-            var firestore = new FirestoreDbBuilder
+                FirebaseApp.Create(new AppOptions
+                {
+                    Credential = credential,
+                    ProjectId = projectId
+                });
+
+                var firestore = new FirestoreDbBuilder
+                {
+                    ProjectId = projectId,
+                    Credential = credential
+
+                }.Build();
+
+                return firestore;
+            }
+            catch (Exception ex)
             {
-                ProjectId = projectId,
-                Credential = credential
-            }.Build();
-
-            return firestore;
+                Console.WriteLine($"Erro Firestore: {ex}");
+                throw;
+            }
         }
     }
 }

--- a/CidadeIntegra/CidadeIntegra.Infra.Data/Firebase/FirestoreProvider.cs
+++ b/CidadeIntegra/CidadeIntegra.Infra.Data/Firebase/FirestoreProvider.cs
@@ -11,7 +11,7 @@ namespace CidadeIntegra.Infra.Data.Firebase
         public FirestoreProvider(IConfiguration configuration)
         {
             var projectId = configuration["Firebase:ProjectId"];
-            var serviceAccountPath = configuration["Firebase:ServiceAccountPath"];
+            var serviceAccountPath = Path.Combine(AppContext.BaseDirectory, "firebase-key.json");
 
             _firestore = FirebaseInitializer.InitializeFirestore(projectId, serviceAccountPath);
         }

--- a/CidadeIntegra/Dockerfile
+++ b/CidadeIntegra/Dockerfile
@@ -1,0 +1,22 @@
+# Etapa única: SDK
+FROM mcr.microsoft.com/dotnet/sdk:6.0
+WORKDIR /app
+
+# Copiar csprojs
+COPY CidadeIntegra.API/CidadeIntegra.API.csproj CidadeIntegra.API/
+COPY CidadeIntegra.Application/CidadeIntegra.Application.csproj CidadeIntegra.Application/
+COPY CidadeIntegra.Infra.IoC/CidadeIntegra.Infra.IoC.csproj CidadeIntegra.Infra.IoC/
+COPY CidadeIntegra.Infra.Data/CidadeIntegra.Infra.Data.csproj CidadeIntegra.Infra.Data/
+
+RUN dotnet restore CidadeIntegra.API/CidadeIntegra.API.csproj
+
+# Copiar toda a solução
+COPY . ./
+
+# Publicar
+RUN dotnet publish CidadeIntegra.API/CidadeIntegra.API.csproj -c Release -o out
+
+WORKDIR /app/out
+COPY CidadeIntegra.API/firebase-key.json ./firebase-key.json
+EXPOSE 80
+ENTRYPOINT ["dotnet", "CidadeIntegra.API.dll"]

--- a/CidadeIntegra/docker-compose.yml
+++ b/CidadeIntegra/docker-compose.yml
@@ -1,0 +1,39 @@
+services:
+  sqlserver:
+    image: mcr.microsoft.com/mssql/server:2022-latest
+    container_name: sqlserver
+    environment:
+      - ACCEPT_EULA=Y
+      - MSSQL_PID=Express
+      - SA_PASSWORD=UndY|n3vc^56
+    ports:
+      - "1433:1433"
+    volumes:
+      - sql_data:/var/opt/mssql
+    networks:
+      - cidadeintegra-network
+
+  api:
+    build:
+      context: ./
+      dockerfile: Dockerfile
+    container_name: cidadeintegra-api
+    environment:
+      - CONNECTION_STRING=${CONNECTION_STRING}
+      - MIGRATION_API_KEY=${MIGRATION_API_KEY}
+      - FIREBASE_ID=${FIREBASE_ID}
+      - FIREBASE_KEY_PATH=${FIREBASE_KEY_PATH}
+      - GOOGLE_APPLICATION_CREDENTIALS=/app/firebase-key.json
+    ports:
+      - "8080:80"
+    depends_on:
+      - sqlserver
+    networks:
+      - cidadeintegra-network
+
+volumes:
+  sql_data:
+
+networks:
+  cidadeintegra-network:
+    driver: bridge

--- a/CidadeIntegra/docker-compose.yml
+++ b/CidadeIntegra/docker-compose.yml
@@ -31,6 +31,27 @@ services:
     networks:
       - cidadeintegra-network
 
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: prometheus
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+    ports:
+      - "9090:9090"
+    networks:
+      - cidadeintegra-network
+
+  grafana:
+    image: grafana/grafana:latest
+    container_name: grafana
+    environment:
+      - GF_SECURITY_ADMIN_USER=admin
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+    ports:
+      - "3000:3000"
+    networks:
+      - cidadeintegra-network
+
 volumes:
   sql_data:
 

--- a/CidadeIntegra/prometheus.yml
+++ b/CidadeIntegra/prometheus.yml
@@ -1,0 +1,8 @@
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: 'cidadeintegra-api'
+    metrics_path: '/metrics'
+    static_configs:
+      - targets: ['cidadeintegra-api:80']  # Nome do serviço no Docker Compose + porta do app


### PR DESCRIPTION
### [5 pontos] Adicionar Docker e Docker Compose

#### Descrição

Containerizar a aplicação para facilitar deploy e execução local com dependências.

#### Objetivo

-   Criar `Dockerfile` da API.    
-   Adicionar `docker-compose.yml` com SQL Server e API.    
-   Configurar variáveis de ambiente e volumes.    
-   Testar `docker-compose up`.
    
#### Pontuação: 5 pontos

#### Branch: `setup/docker-environment-config`